### PR TITLE
Always return model_fields fields in the order requested

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -8,7 +8,8 @@ from sqlalchemy.dialects.postgresql import INET, MACADDR, UUID
 from sqlalchemy.dialects.mysql import YEAR
 from sqlalchemy.dialects.mssql import BIT
 
-from unittest import TestCase
+import sys
+from unittest import TestCase, skipIf
 
 from wtforms.compat import text_type, iteritems
 from wtforms_sqlalchemy.fields import QuerySelectField, QuerySelectMultipleField
@@ -423,3 +424,62 @@ class ModelFormTest(TestCase):
         assert isinstance(form.timestamp, fields.DateTimeField)
 
         assert isinstance(form.date, fields.DateField)
+
+
+@skipIf(
+    sys.version_info < (3, 6),
+    "Model columns and Form fields do not have a stable order on Python 3.5 and earlier")
+class ModelFormOrderTest(TestCase):
+    def setUp(self):
+        Model = declarative_base()
+
+        class AllTypesModel(Model):
+            __tablename__ = "course"
+            id = Column(sqla_types.Integer, primary_key=True)
+            foo = Column(sqla_types.String)
+            bar = Column(sqla_types.String)
+            baz = Column(sqla_types.String)
+
+        self.Model = AllTypesModel
+
+    def test_order_default(self):
+        """Test that fields come out in model order by default."""
+        form = model_form(self.Model)()
+
+        self.assertEqual(
+            [field.name for field in form],
+            ['foo', 'bar', 'baz'])
+
+    def test_only_all_order(self):
+        """
+        Test that fields come out in the specified order when all fields are
+        named in `only`.
+        """
+        form = model_form(self.Model, only=['bar', 'baz', 'foo'])()
+
+        self.assertEqual(
+            [field.name for field in form],
+            ['bar', 'baz', 'foo'])
+
+    def test_only_subset(self):
+        """
+        Test that fields come out in the specified order when all fields are
+        named in `only`.
+        """
+        form = model_form(self.Model, only=['baz', 'foo'])()
+
+        self.assertEqual(
+            [field.name for field in form],
+            ['baz', 'foo'])
+
+    def test_exclude_order(self):
+        """
+        Test that fields come out in model order, ignoring excluded fields.
+        """
+        field_names = ['foo', 'bar', 'baz']
+        for excluded_field in field_names:
+            form = model_form(self.Model, exclude=[excluded_field])()
+
+            self.assertEqual(
+                [field.name for field in form],
+                [f for f in field_names if f != excluded_field])

--- a/wtforms_sqlalchemy/orm.py
+++ b/wtforms_sqlalchemy/orm.py
@@ -4,8 +4,10 @@ Tools for generating forms based on SQLAlchemy models.
 from __future__ import unicode_literals
 
 import inspect
+from collections import OrderedDict
 
-from wtforms import validators, fields as wtforms_fields
+from wtforms import fields as wtforms_fields
+from wtforms import validators
 from wtforms.form import Form
 from .fields import QuerySelectField, QuerySelectMultipleField
 
@@ -238,8 +240,9 @@ def model_fields(model, db_session=None, only=None, exclude=None,
     mapper = model._sa_class_manager.mapper
     converter = converter or ModelConverter()
     field_args = field_args or {}
-    properties = []
 
+    order = []
+    properties = {}
     for prop in mapper.iterate_properties:
         if getattr(prop, 'columns', None):
             if exclude_fk and prop.columns[0].foreign_keys:
@@ -247,16 +250,17 @@ def model_fields(model, db_session=None, only=None, exclude=None,
             elif exclude_pk and prop.columns[0].primary_key:
                 continue
 
-        properties.append((prop.key, prop))
+        order.append(prop.key)
+        properties[prop.key] = prop
 
-    #((p.key, p) for p in mapper.iterate_properties)
     if only:
-        properties = (x for x in properties if x[0] in only)
+        order = list(only)
+        properties = {key: properties[key] for key in only}
     elif exclude:
-        properties = (x for x in properties if x[0] not in exclude)
+        properties = {key: prop for key, prop in properties.items() if key not in exclude}
 
     field_dict = {}
-    for name, prop in properties:
+    for name, prop in properties.items():
         field = converter.convert(
             model, mapper, prop,
             field_args.get(name), db_session
@@ -264,7 +268,7 @@ def model_fields(model, db_session=None, only=None, exclude=None,
         if field is not None:
             field_dict[name] = field
 
-    return field_dict
+    return OrderedDict((key, field_dict[key]) for key in order if key in field_dict)
 
 
 def model_form(model, db_session=None, base_class=Form, only=None,


### PR DESCRIPTION
If specific fields are requested using the 'only' argument, the fields
are now returned in that order. This makes use of ordered dictionary
keys implemented in Python 3.7. Older versions of Python will continue
to scramble the dictionary order as always.