### PR TITLE
Use SQLAlchemy's Column.doc for WTForm's Field.description

### DIFF
--- a/wtforms_sqlalchemy/orm.py
+++ b/wtforms_sqlalchemy/orm.py
@@ -81,6 +81,7 @@ class ModelConverterBase(object):
             'validators': [],
             'filters': [],
             'default': None,
+            'description': prop.doc
         }
 
         if field_args:


### PR DESCRIPTION
Pull the column doc attribute for the form field description. This allows setting help text on the model which can automatically be passed to all fields generated from `model_form`. Users can still override this using `field_args` if desired, or simply not print it out in their forms if they don't like it.