### PR TITLE
 Use specific EnumSelectField for PEP-435 enum columns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: xenial
 language: python
 
 python:
-  - 2.7
   - 3.5
   - 3.6
   - 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,19 +12,10 @@ env:
   global:
     - WTFORMS="<3"
   matrix:
-    - SQLALCHEMY="==0.7.10"
-    - SQLALCHEMY="~=0.8.6"
-    - SQLALCHEMY="==0.8.6" WTFORMS="==1.0.5"
-    - SQLALCHEMY="~=0.9.6"
-    - SQLALCHEMY="==0.9.8" WTFORMS="==1.0.5"
+    - SQLALCHEMY="~=1.1.0"
+    - SQLALCHEMY="~=1.2.0"
+    - SQLALCHEMY="~=1.3.0"
     - SQLALCHEMY=""
-
-jobs:
-  exclude:
-  - python: 3.8
-    env: SQLALCHEMY="==0.8.6" WTFORMS="==1.0.5"
-  - python: 3.8
-    env: SQLALCHEMY="==0.9.8" WTFORMS="==1.0.5"
 
 # command to install dependencies
 install:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -227,12 +227,36 @@ class EnumSelectFieldTest(TestBase):
     def test_field_data(self):
         class F(Form):
             a = EnumSelectField(enum=Fruit)
+
+        form = F(data={'a': Fruit.banana})
+        self.assertTrue(form.validate())
+        self.assertIs(form.data['a'], Fruit.banana)
+
+        form = F(data={'a': 'banana'})
+        self.assertTrue(form.validate())
+        self.assertIs(form.data['a'], Fruit.banana)
+
+        form = F(data={'a': None})
+        self.assertTrue(form.validate())
+        self.assertIs(form.data['a'], None)
+
+    def test_field_formdata(self):
+        class F(Form):
+            a = EnumSelectField(enum=Fruit)
+
         form = F(DummyPostData(a=['banana']))
         self.assertEqual(
             list(form.a.iter_choices()),
             [('apple', 'Apple', False), ('banana', 'Banana', True), ('orange', 'Orange', False)])
         self.assertTrue(form.validate())
         self.assertIs(form.data['a'], Fruit.banana)
+
+        form = F(DummyPostData(a=[]))
+        self.assertEqual(
+            list(form.a.iter_choices()),
+            [('', 'Select...', True), ('apple', 'Apple', False), ('banana', 'Banana', False), ('orange', 'Orange', False)])
+        self.assertTrue(form.validate())
+        self.assertIsNone(form.data['a'])
 
     def test_invalid_choice(self):
         class F(Form):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37, py38, pypy, pypy3
+envlist = py35, py36, py37, py38, pypy3
 
 [testenv]
 setenv =

--- a/wtforms_sqlalchemy/orm.py
+++ b/wtforms_sqlalchemy/orm.py
@@ -9,7 +9,8 @@ from collections import OrderedDict
 from wtforms import fields as wtforms_fields
 from wtforms import validators
 from wtforms.form import Form
-from .fields import QuerySelectField, QuerySelectMultipleField
+
+from .fields import EnumSelectField, QuerySelectField, QuerySelectMultipleField
 
 __all__ = (
     'model_fields', 'model_form',
@@ -189,8 +190,12 @@ class ModelConverter(ModelConverterBase):
     @converts('Enum')
     def conv_Enum(self, column, field_args, **extra):
         self._nullable_required(column=column, field_args=field_args, **extra)
-        field_args['choices'] = [(e, e) for e in column.type.enums]
-        return wtforms_fields.SelectField(**field_args)
+        if column.type.enum_class is not None:
+            field_args['enum'] = column.type.enum_class
+            return EnumSelectField(**field_args)
+        else:
+            field_args['choices'] = [(e, e) for e in column.type.enums]
+            return wtforms_fields.SelectField(**field_args)
 
     @converts('Integer')  # includes BigInteger and SmallInteger
     def handle_integer_types(self, column, field_args, **extra):


### PR DESCRIPTION
Enum columns are excellent, supporting them natively in the forms makes them very nice to work with.

This is a redo of #8, but significantly better. I had made some further refinements for the project I initially made this for, added a few more options, and added the EnumSelectMultipleField for arrays of enums. I've also added tests for both fields.

Making the tests pass required dropping Python 2 tests, as discussed in #8.